### PR TITLE
Accept single URLs (hostname only) as valid

### DIFF
--- a/qml/pages/LoginDialog.qml
+++ b/qml/pages/LoginDialog.qml
@@ -71,15 +71,13 @@ Dialog {
 
             TextField {
                 id: serverField
-                // regExp combined from https://stackoverflow.com/a/3809435 (EDIT: removed ? after https to force SSL) and https://www.regextester.com/22
-                property var encryptedRegEx: /^https:\/\/(((www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b|((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))))([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/
-                property var unencryptedRegEx : /^https?:\/\/(((www\.)?[-a-zA-Z0-9@:%._\+~#=]{2,256}\.[a-z]{2,6}\b|((([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5])\.){3}([0-9]|[1-9][0-9]|1[0-9]{2}|2[0-4][0-9]|25[0-5]))))([-a-zA-Z0-9@:%_\+.~#?&//=]*)$/
+                property var httpRegEx: /^https?:\/\/.+$/
                 width: parent.width
                 text: account.value("server", "https://", String)
                 placeholderText: qsTr("Nextcloud server")
                 label: placeholderText + " " + qsTr("(starting with \"https://\")")
                 inputMethodHints: Qt.ImhUrlCharactersOnly
-                validator: RegExpValidator { regExp: unencryptedConnectionTextSwitch.checked ? serverField.unencryptedRegEx : serverField.encryptedRegEx }
+                validator: RegExpValidator { regExp: httpRegEx }
                 errorHighlight: !acceptableInput// && focus === true
                 EnterKey.enabled: acceptableInput
                 EnterKey.iconSource: "image://theme/icon-m-enter-next"


### PR DESCRIPTION
I cannot login because I'm using a single URL (https://foo) which fails to pass the regular expression. This kind of URLs can be used in combination with Tailscale's magic DNS feature or with any local DNS server.

I suppose that nowadays checking for any URL that starts with `http://` or `https://` should be enough.