### PR TITLE
Use API v1

### DIFF
--- a/qml/pages/NotesApi.qml
+++ b/qml/pages/NotesApi.qml
@@ -7,7 +7,7 @@ Item {
     property string name
     property url server
     property url url
-    property string version: "v0.2"
+    property string version: "v1"
     property string username
     property string password
     property date update


### PR DESCRIPTION
I changed only the api version property, and for now it seems to still work (and it resolves my issue!). I'll use this for a while and update the PR if necessary.

Observations/TODOs:
- [x] Creating a new note requires to set the title field (or the note will be called "New note" by default).

Fixes #61 
